### PR TITLE
Handle Icepay postbacks that do not contain all fields.

### DIFF
--- a/icepay/client.py
+++ b/icepay/client.py
@@ -75,7 +75,7 @@ class IcepayClient:
             data.get('ConsumerIPAddress')
         ]
 
-        sig = '|'.join([str(x) for x in parts])
+        sig = '|'.join(str(x) for x in parts if x is not None)
 
         m = hashlib.sha1()
         m.update(sig.encode('utf8'))


### PR DESCRIPTION
Using the Icepay test environment, postbacks lack values for the Amount, Currency, Duration and ConsumerIPAddress. Whether or not this is intended by the API or not, and in which situations this is the case seems undocumented, but does occur.

The checksum code on Icepay's postback is calculated only from the provided fields, with the fields not present skipped (including delimiters) as if they were not needed for checksumming at all.